### PR TITLE
fix(build native): :ambulance: Tentative avec Xmx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
                                 <tags>${spring-boot.build-image.tags}</tags>
                                 <env>
                                     <BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>
-                                    <BP_NATIVE_IMAGE_BUILD_ARGUMENTS>-R:MaxHeapSize=7g</BP_NATIVE_IMAGE_BUILD_ARGUMENTS>
+                                    <BP_NATIVE_IMAGE_BUILD_ARGUMENTS>-J-Xmx6G -H:+ReportExceptionStackTraces -H:-CheckToolchain</BP_NATIVE_IMAGE_BUILD_ARGUMENTS>
                                 </env>
                             </image>
                         </configuration>


### PR DESCRIPTION
Il se pourrait qu'il y ait un problème qui fait que la mémoire est litmité à 1g,

fix #122